### PR TITLE
Add feature to load the next chapter when a story ends

### DIFF
--- a/assets/quests/1-frostbound_peaks.json
+++ b/assets/quests/1-frostbound_peaks.json
@@ -2,5 +2,16 @@
     "title": "Frostbound Peaks",
     "name": "1-frostbound_peaks",
     "next_chapter": "2-sunken_ruins",
-    "introduction": null
+    "introduction": "You've reached the frostbound peaks introduction.",
+    "1": {
+        "description": "You've reached the frostbound peaks.",
+        "choices": {
+            "1": "Be a happy developer.",
+            "2": "Be a happy developer."
+        },
+        "nextSegmentIds": {
+            "1": 1,
+            "2": 1
+        }
+    }
 }

--- a/include/Game.h
+++ b/include/Game.h
@@ -31,6 +31,7 @@ class Game {
     Story story;
 
     void displayMainMenu();
+    void loadNextStory();
     void processMainMenuInput();
 };
 

--- a/include/Story.h
+++ b/include/Story.h
@@ -10,13 +10,16 @@ struct StorySegment {
     std::string description;
     std::map<int, std::string> choices;
     std::map<int, int> nextSegmentIds;
+    bool chapterEnd = false;
 };
 
 class Story {
  public:
-    void Story::loadStory(const std::string& saveFile);
+    std::string getNextStoryName();
+    void loadStory(const std::string& saveFile);
     void nextSegment(int choice);
-    void printSegment();
+    bool printSegment();
+    void unloadStory();
 
  private:
     int currentSegmentId;

--- a/include/Story.h
+++ b/include/Story.h
@@ -19,8 +19,9 @@ class Story {
     void printSegment();
 
  private:
-    std::unordered_map<int, StorySegment> storySegments;
     int currentSegmentId;
+    std::string nextStoryName;
+    std::unordered_map<int, StorySegment> storySegments;
 };
 
 #endif  // INCLUDE_STORY_H_

--- a/include/Story.h
+++ b/include/Story.h
@@ -14,7 +14,7 @@ struct StorySegment {
 
 class Story {
  public:
-    void loadStory();
+    void Story::loadStory(const std::string& saveFile);
     void nextSegment(int choice);
     void printSegment();
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -6,6 +6,12 @@
 
 const char* GAME_TITLE = "Shattered Kingdom";
 
+void Game::displayMainMenu() {
+    std::cout << "Main Menu" << std::endl;
+    std::cout << "1. Start Game" << std::endl;
+    std::cout << "2. Quit" << std::endl;
+}
+
 void Game::endGame() {
     std::cout << "Thanks for playing " << GAME_TITLE << "!" << std::endl;
     gameState = GameState::GameOver;
@@ -31,12 +37,7 @@ void Game::loadNextStory() {
 
     story.unloadStory();
     story.loadStory(nextStory);
-}
-
-void Game::displayMainMenu() {
-    std::cout << "Main Menu" << std::endl;
-    std::cout << "1. Start Game" << std::endl;
-    std::cout << "2. Quit" << std::endl;
+    story.printSegment();
 }
 
 void Game::processInput() {

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -21,6 +21,19 @@ bool Game::isGameOver() {
     return gameState == GameState::GameOver;
 }
 
+void Game::loadNextStory() {
+    std::string nextStory = story.getNextStoryName();
+
+    if (nextStory.empty()) {
+        endGame();
+        return;
+    }
+
+    story.unloadStory();
+    story.loadStory(nextStory);
+    std::cout << "Loading next story..." << std::endl;
+}
+
 void Game::displayMainMenu() {
     std::cout << "Main Menu" << std::endl;
     std::cout << "1. Start Game" << std::endl;
@@ -62,7 +75,9 @@ void Game::update() {
             showMainMenu();
             break;
         case GameState::InGame:
-            story.printSegment();
+            if (!story.printSegment()) {
+                loadNextStory();
+            }
             break;
         case GameState::GameOver:
             break;

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -13,7 +13,7 @@ void Game::endGame() {
 
 void Game::initialize() {
     std::cout << "Welcome to " << GAME_TITLE << "!" << std::endl;
-    story.loadStory();
+    story.loadStory("0-plentiful_valley");
     gameState = GameState::MainMenu;
 }
 

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -31,7 +31,6 @@ void Game::loadNextStory() {
 
     story.unloadStory();
     story.loadStory(nextStory);
-    std::cout << "Loading next story..." << std::endl;
 }
 
 void Game::displayMainMenu() {

--- a/src/Story.cpp
+++ b/src/Story.cpp
@@ -9,6 +9,10 @@
 
 using json = nlohmann::json;
 
+std::string Story::getNextStoryName() {
+    return nextStoryName;
+}
+
 void Story::loadStory(const std::string& saveFile) {
     std::string filePath = "assets/quests/" + saveFile + ".json";
     std::ifstream file(filePath);
@@ -31,15 +35,17 @@ void Story::loadStory(const std::string& saveFile) {
 
     // Iterate over story data
     for (auto& [id, segment] : storyData.items()) {
-        StorySegment storySegment;
-
         // Check if "description" exists
-        if (segment.contains("description")) {
-            storySegment.description = segment["description"];
-        } else {
-            std::cerr << "Warning: Missing 'description' for story segment "
-                      << id << std::endl;
+        if (!segment.contains("description")) {
             continue;  // Skip this segment if essential data is missing
+        }
+
+        StorySegment storySegment;
+        storySegment.description = segment["description"];
+
+        // Parse chapter_end if it exists
+        if (segment.contains("chapter_end")) {
+            storySegment.chapterEnd = true;
         }
 
         // Parse choices if they exist
@@ -78,12 +84,17 @@ void Story::loadStory(const std::string& saveFile) {
     }
 
     // Indicate the story has been loaded successfully
-    std::cout << "Story loaded! Total segments: "
-              << storySegments.size() << std::endl;
+    std::cout << storyData["introduction"] << std::endl;
 }
 
 void Story::nextSegment(int choice) {
     const auto& currentSegment = storySegments[currentSegmentId];
+
+    if (currentSegment.chapterEnd) {
+        std::cerr << "Error: Cannot move to next segment, story is over!"
+                  << std::endl;
+        return;
+    }
 
     if (currentSegment.choices.find(choice) == currentSegment.choices.end()) {
         std::cerr << "Error: Invalid choice ID " << choice << std::endl;
@@ -99,13 +110,19 @@ void Story::nextSegment(int choice) {
     }
 }
 
-void Story::printSegment() {
+bool Story::printSegment() {
+    // If the key `"chapter_end": true` is met, the story is over, return false
     const auto& segment = storySegments[currentSegmentId];
 
-    std::cout << "------------------------" << std::endl;
-    std::cout << "Description: " << segment.description << std::endl;
+    if (segment.chapterEnd) {
+        return false;
+    }
 
-    std::cout << "Choices:" << std::endl;
+    std::cout << "------------------------" << std::endl;
+    std::cout << segment.description << std::endl;
+    std::cout << std::endl;
+
+    std::cout << "Choose an option:" << std::endl;
 
     std::vector<std::pair<int, std::string>> sortedChoices(
         segment.choices.begin(), segment.choices.end());
@@ -117,4 +134,12 @@ void Story::printSegment() {
     }
 
     std::cout << "------------------------" << std::endl;
+
+    return true;
+}
+
+void Story::unloadStory() {
+    storySegments.clear();
+    currentSegmentId = 0;
+    nextStoryName.clear();
 }

--- a/src/Story.cpp
+++ b/src/Story.cpp
@@ -3,17 +3,19 @@
 
 #include <fstream>
 #include <iostream>
+#include <string>
 
 #include "nlohmann/json.hpp"
 
 using json = nlohmann::json;
 
-void Story::loadStory() {
-    std::ifstream file("assets/quests/0-plentiful_valley.json");
+void Story::loadStory(const std::string& saveFile) {
+    std::string filePath = "assets/quests/" + saveFile + ".json";
+    std::ifstream file(filePath);
 
     // Check if file opened successfully
     if (!file.is_open()) {
-        std::cerr << "Error: Could not open plot.json file!" << std::endl;
+        std::cerr << "Error: Could not open " << saveFile << "!" << std::endl;
         return;
     }
 

--- a/src/Story.cpp
+++ b/src/Story.cpp
@@ -71,6 +71,12 @@ void Story::loadStory(const std::string& saveFile) {
     // Set the current segment to the first segment
     currentSegmentId = 1;
 
+    // Save the next story name if it exists
+    if (storyData.contains("next_chapter") &&
+        !storyData["next_chapter"].is_null()) {
+        nextStoryName = storyData["next_chapter"];
+    }
+
     // Indicate the story has been loaded successfully
     std::cout << "Story loaded! Total segments: "
               << storySegments.size() << std::endl;


### PR DESCRIPTION
## Description:

This PR introduces a new feature that allows the game to automatically load the next chapter when the current chapter ends. Previously, the game would stop after a chapter finished without transitioning to the next story. The following changes were made to support this feature:

## Changes:

- **Story progression:**
  - The game now checks if the current chapter is over by evaluating if the `"chapter_end": true` key is set in the JSON file.
  - When the end of a chapter is reached, the next chapter is loaded automatically if it exists. If no further chapters are available, the game ends.
  
- **New behavior:**
  - After completing a chapter, the next chapter is loaded and the first segment of the new chapter is displayed immediately, ensuring a smooth continuation of the game.
  
- **Code improvements:**
  - Added `story.printSegment()` call after loading the next chapter to ensure the first segment is displayed correctly.
  - Improved error handling when loading story files, ensuring proper feedback if issues occur during file parsing or transition to the next chapter.

## Testing:
- Manually tested transitions between chapters with different story segments and confirmed that the next chapter loads correctly when the current one ends.
- Verified that the game ends properly if no further chapters are available.

## Notes:
- This PR improves user experience by enabling continuous gameplay without manual intervention when chapters change.
- JSON structure for stories now supports the `"next_chapter"` key, which should be correctly set in each chapter’s file for proper linking between stories.
